### PR TITLE
Feature/magento 2350 getcart pipeline supports v2

### DIFF
--- a/extension/cart/createProductCartItemList.js
+++ b/extension/cart/createProductCartItemList.js
@@ -55,11 +55,11 @@ module.exports = function (context, input, cb) {
     } else {
       transformedProduct = new SimpleProduct(products[i].productId, products[i].quantity)
     }
-    if (products[i].hasOwnProperty('properties')) {
-      products[i].properties.forEach(function (property) {
+    if (products[i].hasOwnProperty('options')) {
+      products[i].options.forEach(function (option) {
         transformedProduct.addOptions(
-          property.id,
-          property.value
+          option.id,
+          option.value
         )
       })
     }

--- a/extension/cart/transformToShopgateCart.js
+++ b/extension/cart/transformToShopgateCart.js
@@ -206,7 +206,7 @@ function getCartItems (magentoCart, shopgateProducts) {
           const allowedTypes = ['field', 'area']
           return allowedTypes.includes(option.option_type)
         }).forEach(option => {
-          const property = new Property('option', option.value)
+          const property = new Property('input', option.value)
           property.setLabel(option.label)
           product.addProperty(property)
         })

--- a/extension/test/newman/collection.json
+++ b/extension/test/newman/collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "b5fe4c6f-d279-48ae-b65c-e7cac04a58ed",
+		"_postman_id": "5f8a0be4-11dc-4661-a5b6-f6d2c1d2d6c8",
 		"name": "Magento Connect - Cart",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -128,7 +128,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n\t\"products\": [\n\t\t{\n\t\t\t\"productId\": 553,\n\t\t\t\"quantity\": 1,\n\t\t\t\"properties\": [\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"input\",\n\t\t\t\t\t\"id\": \"7\",\n\t\t\t\t\t\"value\": \"DEMO Text is too long\"\n\t\t\t\t}\n\t\t\t\t]\n\t\t}\n\t\t]\n}"
+											"raw": "{\n\t\"products\": [\n\t\t{\n\t\t\t\"productId\": 553,\n\t\t\t\"quantity\": 1,\n\t\t\t\"options\": [\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"text\",\n\t\t\t\t\t\"id\": \"7\",\n\t\t\t\t\t\"value\": \"DEMO Text is too long\"\n\t\t\t\t}\n\t\t\t\t]\n\t\t}\n\t\t]\n}"
 										},
 										"url": {
 											"raw": "{{domain}}{{endpoint_cart_products_add}}",
@@ -158,7 +158,7 @@
 													"});",
 													"",
 													"pm.test('Error has the right format', function () {",
-													"    pm.expect(response.error.message).to.equal('Product(s) could not be added. The text is too long')",
+													"    pm.expect(response.error.message).to.equal('Product(s) could not be added. Please specify the product required option(s).')",
 													"});"
 												],
 												"type": "text/javascript"
@@ -175,7 +175,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n\t\"products\": [\n\t\t{\n\t\t\t\"productId\": 553,\n\t\t\t\"quantity\": 1,\n\t\t\t\"properties\": [\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"input\",\n\t\t\t\t\t\"id\": \"8\",\n\t\t\t\t\t\"value\": \"DEMO Text\"\n\t\t\t\t}\n\t\t\t\t]\n\t\t}\n\t\t]\n}"
+											"raw": "{\n\t\"products\": [\n\t\t{\n\t\t\t\"productId\": 553,\n\t\t\t\"quantity\": 1,\n\t\t\t\"options\": [\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"text\",\n\t\t\t\t\t\"id\": \"8\",\n\t\t\t\t\t\"value\": \"DEMO Text\"\n\t\t\t\t}\n\t\t\t\t]\n\t\t}\n\t\t]\n}"
 										},
 										"url": {
 											"raw": "{{domain}}{{endpoint_cart_products_add}}",
@@ -266,7 +266,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"products\": [\n\t\t{\n\t\t\t\"productId\": 553,\n\t\t\t\"quantity\": 1,\n\t\t\t\"properties\": [\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"input\",\n\t\t\t\t\t\"id\": \"7\",\n\t\t\t\t\t\"value\": \"DEMO Text\"\n\t\t\t\t}\n\t\t\t\t]\n\t\t}\n\t\t]\n}"
+									"raw": "{\n\t\"products\": [\n\t\t{\n\t\t\t\"productId\": 553,\n\t\t\t\"quantity\": 1,\n\t\t\t\"options\": [\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"text\",\n\t\t\t\t\t\"id\": \"7\",\n\t\t\t\t\t\"value\": \"DEMO Text\"\n\t\t\t\t}\n\t\t\t\t]\n\t\t}\n\t\t]\n}"
 								},
 								"url": {
 									"raw": "{{domain}}{{endpoint_cart_products_add}}",
@@ -356,7 +356,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"products\": [\n\t\t{\n\t\t\t\"productId\": 370,\n\t\t\t\"quantity\": 1,\n\t\t\t\"properties\": [\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"input\",\n\t\t\t\t\t\"id\": \"4\",\n\t\t\t\t\t\"value\": \"DEMO Text\"\n\t\t\t\t}\n\t\t\t\t]\n\t\t}\n\t\t]\n}"
+									"raw": "{\n\t\"products\": [\n\t\t{\n\t\t\t\"productId\": 370,\n\t\t\t\"quantity\": 1,\n\t\t\t\"options\": [\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"text\",\n\t\t\t\t\t\"id\": \"4\",\n\t\t\t\t\t\"value\": \"DEMO Text\"\n\t\t\t\t}\n\t\t\t\t]\n\t\t}\n\t\t]\n}"
 								},
 								"url": {
 									"raw": "{{domain}}{{endpoint_cart_products_add}}",
@@ -531,7 +531,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n\t\"products\": [\n\t\t{\n\t\t\t\"productId\": 553,\n\t\t\t\"quantity\": 1,\n\t\t\t\"properties\": [\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"input\",\n\t\t\t\t\t\"id\": \"7\",\n\t\t\t\t\t\"value\": \"DEMO Text is too long\"\n\t\t\t\t}\n\t\t\t\t]\n\t\t}\n\t\t]\n}"
+											"raw": "{\n\t\"products\": [\n\t\t{\n\t\t\t\"productId\": 553,\n\t\t\t\"quantity\": 1,\n\t\t\t\"options\": [\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"text\",\n\t\t\t\t\t\"id\": \"7\",\n\t\t\t\t\t\"value\": \"DEMO Text is too long\"\n\t\t\t\t}\n\t\t\t\t]\n\t\t}\n\t\t]\n}"
 										},
 										"url": {
 											"raw": "{{domain}}{{endpoint_cart_products_add}}",
@@ -574,7 +574,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n\t\"products\": [\n\t\t{\n\t\t\t\"productId\": 553,\n\t\t\t\"quantity\": 1,\n\t\t\t\"properties\": [\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"input\",\n\t\t\t\t\t\"id\": \"8\",\n\t\t\t\t\t\"value\": \"DEMO Text is too long\"\n\t\t\t\t}\n\t\t\t\t]\n\t\t}\n\t\t]\n}"
+											"raw": "{\n\t\"products\": [\n\t\t{\n\t\t\t\"productId\": 553,\n\t\t\t\"quantity\": 1,\n\t\t\t\"options\": [\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"text\",\n\t\t\t\t\t\"id\": \"8\",\n\t\t\t\t\t\"value\": \"DEMO Text is too long\"\n\t\t\t\t}\n\t\t\t\t]\n\t\t}\n\t\t]\n}"
 										},
 										"url": {
 											"raw": "{{domain}}{{endpoint_cart_products_add}}",
@@ -661,7 +661,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"products\": [\n\t\t{\n\t\t\t\"productId\": 553,\n\t\t\t\"quantity\": 1,\n\t\t\t\"properties\": [\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"input\",\n\t\t\t\t\t\"id\": \"7\",\n\t\t\t\t\t\"value\": \"DEMO Text\"\n\t\t\t\t}\n\t\t\t\t]\n\t\t}\n\t\t]\n}"
+									"raw": "{\n\t\"products\": [\n\t\t{\n\t\t\t\"productId\": 553,\n\t\t\t\"quantity\": 1,\n\t\t\t\"options\": [\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"text\",\n\t\t\t\t\t\"id\": \"7\",\n\t\t\t\t\t\"value\": \"DEMO Text\"\n\t\t\t\t}\n\t\t\t\t]\n\t\t}\n\t\t]\n}"
 								},
 								"url": {
 									"raw": "{{domain}}{{endpoint_cart_products_add}}",
@@ -751,7 +751,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"products\": [\n\t\t{\n\t\t\t\"productId\": 370,\n\t\t\t\"quantity\": 1,\n\t\t\t\"properties\": [\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"input\",\n\t\t\t\t\t\"id\": \"4\",\n\t\t\t\t\t\"value\": \"DEMO Text\"\n\t\t\t\t}\n\t\t\t\t]\n\t\t}\n\t\t]\n}"
+									"raw": "{\n\t\"products\": [\n\t\t{\n\t\t\t\"productId\": 370,\n\t\t\t\"quantity\": 1,\n\t\t\t\"options\": [\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"text\",\n\t\t\t\t\t\"id\": \"4\",\n\t\t\t\t\t\"value\": \"DEMO Text\"\n\t\t\t\t}\n\t\t\t\t]\n\t\t}\n\t\t]\n}"
 								},
 								"url": {
 									"raw": "{{domain}}{{endpoint_cart_products_add}}",

--- a/extension/test/newman/collection.json
+++ b/extension/test/newman/collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "64fbe02d-498e-402e-a247-92b1ebf9df58",
+		"_postman_id": "b5fe4c6f-d279-48ae-b65c-e7cac04a58ed",
 		"name": "Magento Connect - Cart",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -297,7 +297,7 @@
 											"    const {product: {properties}} = desiredCartItem",
 											"    pm.expect(properties).to.be.an('array')",
 											"    const textInputProperty = properties[0]",
-											"    pm.expect(textInputProperty.type).to.equal('option')",
+											"    pm.expect(textInputProperty.type).to.equal('input')",
 											"    pm.expect(textInputProperty.label).to.equal('Engraving')",
 											"    pm.expect(textInputProperty.value).to.equal('DEMO Text')",
 											"})",
@@ -387,7 +387,7 @@
 											"    const {product: {properties}} = desiredCartItem",
 											"    pm.expect(properties).to.be.an('array')",
 											"    const textInputProperty = properties[0]",
-											"    pm.expect(textInputProperty.type).to.equal('option')",
+											"    pm.expect(textInputProperty.type).to.equal('input')",
 											"    pm.expect(textInputProperty.label).to.equal('Monogramming')",
 											"    pm.expect(textInputProperty.value).to.equal('DEMO Text')",
 											"})",
@@ -692,7 +692,7 @@
 											"    const {product: {properties}} = desiredCartItem",
 											"    pm.expect(properties).to.be.an('array')",
 											"    const textInputProperty = properties[0]",
-											"    pm.expect(textInputProperty.type).to.equal('option')",
+											"    pm.expect(textInputProperty.type).to.equal('input')",
 											"    pm.expect(textInputProperty.label).to.equal('Engraving')",
 											"    pm.expect(textInputProperty.value).to.equal('DEMO Text')",
 											"})",
@@ -782,7 +782,7 @@
 											"    const {product: {properties}} = desiredCartItem",
 											"    pm.expect(properties).to.be.an('array')",
 											"    const textInputProperty = properties[0]",
-											"    pm.expect(textInputProperty.type).to.equal('option')",
+											"    pm.expect(textInputProperty.type).to.equal('input')",
 											"    pm.expect(textInputProperty.label).to.equal('Monogramming')",
 											"    pm.expect(textInputProperty.value).to.equal('DEMO Text')",
 											"})",

--- a/extension/test/unit/cart/createProductCartItemList-test.js
+++ b/extension/test/unit/cart/createProductCartItemList-test.js
@@ -32,7 +32,7 @@ describe('createProductCartItemList', () => {
       {
         productId: '2',
         quantity: 1,
-        properties: [
+        options: [
           { id: '68', value: 'Text Input' }
         ]
       }

--- a/extension/test/unit/cart/transformToShopgateCart-test.js
+++ b/extension/test/unit/cart/transformToShopgateCart-test.js
@@ -108,7 +108,7 @@ describe('transformToShopgateCart', () => {
     it('should return a product with text input option', (done) => {
       step(context, input, (err, result) => {
         const property = result.cartItems[3].product.properties[0]
-        assert.strictEqual(property.type, 'option')
+        assert.strictEqual(property.type, 'input')
         assert.ifError(err)
         expect(resultingCart).to.eql(result)
         done()

--- a/extension/test/unit/data/shopgate-cart.json
+++ b/extension/test/unit/data/shopgate-cart.json
@@ -63,7 +63,7 @@
         "properties": [
           {
             "label": "Monogramming",
-            "type": "option",
+            "type": "input",
             "value": "Sample text"
           }
         ]


### PR DESCRIPTION
# Pull Request Template

## Description

Switch getCart property type from "option" to "input" and adjust the tests
Detect options from the ShopgateProduct and map to addProduct functionality 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I updated the CHANGELOG.md